### PR TITLE
Fix encoding for long_description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Thank you for your useful package.

When installing the package with `pip install git+https://github.com/JoHof/lungmask`, I faced this error: ` UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1989: ordinal not in range(128)`

This issue happened as discussed here: https://discuss.python.org/t/pep-597-use-utf-8-for-default-text-file-encoding/1819

To help it work in case users don't set `LANG="en_us.UTF-8"` in their shell config file, we should set `encoding='utf-8'` when open `README.md` file in `setup.py`.



