### PR TITLE
Remove num_workers option from validation DataLoader

### DIFF
--- a/lungmask/mask.py
+++ b/lungmask/mask.py
@@ -59,8 +59,7 @@ def apply(image, model=None, force_cpu=False, batch_size=20, volume_postprocessi
         sanity = [(tvolslices[x]>0.6).sum()>25000 for x in range(len(tvolslices))]
         tvolslices = tvolslices[sanity]
     torch_ds_val = utils.LungLabelsDS_inf(tvolslices)
-    dataloader_val = torch.utils.data.DataLoader(torch_ds_val, batch_size=batch_size, shuffle=False, num_workers=1,
-                                                 pin_memory=False)
+    dataloader_val = torch.utils.data.DataLoader(torch_ds_val, batch_size=batch_size, shuffle=False, pin_memory=False)
 
     timage_res = np.empty((np.append(0, tvolslices[0].shape)), dtype=np.uint8)
 


### PR DESCRIPTION
Setting the `num_workers` option to the validation DataLoader does not have any benefit (at least for pytorch 1.8+).
If this is set it doesn't allow to specify number of CPU threads in case one wants to limit the CPU usage
i.e. `torch.set_num_threads(8)` will break the execution.