### PR TITLE
Fix/no download when path

### DIFF
--- a/lungmask/utils.py
+++ b/lungmask/utils.py
@@ -252,6 +252,7 @@ def postprocessing(
     Returns:
         np.ndarray: Postprocessed volume
     """
+    logging.info("Postprocessing")
 
     # CC analysis
     regionmask = skimage.measure.label(label_image)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lungmask",
-    version="0.2.14",
+    version="0.2.15",
     author="Johannes Hofmanninger",
     author_email="johannes.hofmanninger@gmail.com",
     description="Package for automated lung segmentation in CT",

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,10 +1,11 @@
 import os
+import shutil
 
 import numpy as np
-import pydicom as pyd
 import pytest
+import torch
 
-from lungmask.mask import LMInferer, apply, apply_fused
+from lungmask.mask import MODEL_URLS, LMInferer
 from lungmask.utils import read_dicoms
 
 
@@ -13,8 +14,32 @@ def fixture_testvol():
     return read_dicoms(os.path.join(os.path.dirname(__file__), "testdata"))[0]
 
 
-def test_LMInferer(fixture_testvol):
+@pytest.fixture(scope="session")
+def fixture_weights_path_R231(tmpdir_factory):
+    # we make sure the model is there
+    torch.hub.load_state_dict_from_url(
+        MODEL_URLS["R231"][0], progress=True, map_location=torch.device("cpu")
+    )
+    modelbasename = os.path.basename(MODEL_URLS["R231"][0])
+    modelpath = os.path.join(torch.hub.get_dir(), "checkpoints", modelbasename)
+    tmppath = str(tmpdir_factory.mktemp("weights").join(modelbasename))
+    shutil.copy(modelpath, tmppath)
+    return tmppath
+
+
+def test_LMInferer(fixture_testvol, fixture_weights_path_R231):
     inferer = LMInferer(
+        force_cpu=True,
+        tqdm_disable=True,
+    )
+    res = inferer.apply(fixture_testvol)
+    assert np.all(np.unique(res, return_counts=True)[1] == [423000, 64752, 36536])
+
+    # here, we provide a path to the R231 weights but specify LTRCLobes (6 channel) as modelname
+    # The modelname should be ignored and a 3 channel output should be generated
+    inferer = LMInferer(
+        modelname="LTRCLobes",
+        modelpath=fixture_weights_path_R231,
         force_cpu=True,
         tqdm_disable=True,
     )

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -13,13 +13,23 @@ def fixture_testvol():
     return read_dicoms(os.path.join(os.path.dirname(__file__), "testdata"))[0]
 
 
-def test_apply(fixture_testvol):
-    res = apply(fixture_testvol)
+def test_LMInferer(fixture_testvol):
+    inferer = LMInferer(
+        force_cpu=True,
+        tqdm_disable=True,
+    )
+    res = inferer.apply(fixture_testvol)
     assert np.all(np.unique(res, return_counts=True)[1] == [423000, 64752, 36536])
 
 
-def test_apply_fused(fixture_testvol):
-    res = apply_fused(fixture_testvol)
+def test_LMInferer_fused(fixture_testvol):
+    inferer = LMInferer(
+        modelname="LTRCLobes",
+        force_cpu=True,
+        fillmodel="R231",
+        tqdm_disable=True,
+    )
+    res = inferer.apply(fixture_testvol)
     assert np.all(
         np.unique(res, return_counts=True)[1] == [423000, 13334, 23202, 23834, 40918]
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,7 @@
 import os
 
 import numpy as np
-import pydicom as pd
-import pydicom as pyd
 import SimpleITK as sitk
-from pydicom.dataset import FileMetaDataset
 
 from lungmask.utils import (
     bbox_3D,
@@ -18,6 +15,9 @@ from lungmask.utils import (
 )
 
 # creating test dicom data for reference
+# import pydicom as pd
+# import pydicom as pyd
+# from pydicom.dataset import FileMetaDataset
 #
 # studyuid = pyd.uid.generate_uid()
 # seriesuid = pyd.uid.generate_uid()


### PR DESCRIPTION
This fix allows to directly provide a modelpath to the LMInferer constructor avoiding the download of the model weights. There are also a couple commits for code cleaning