### PR TITLE
Check for Apple Metal support and use if available

### DIFF
--- a/lungmask/mask.py
+++ b/lungmask/mask.py
@@ -122,6 +122,12 @@ class LMInferer:
         if not self.force_cpu:
             if torch.cuda.is_available():
                 self.device = torch.device("cuda")
+            elif torch.backends.mps.is_available():
+                if torch.backends.mps.is_built():
+                    self.device = torch.device("mps")
+                    logger.info("An Apple Metal device is detected and will be used. Use --cpu to disable Metal and force running on CPU.")
+                else:
+                    logger.info("An Apple Metal device is detected but will not be used because this version of PyTorch is not built with Metal support.")
             else:
                 logger.info("No GPU found, using CPU instead")
         self.model.to(self.device)


### PR DESCRIPTION
Hello,

I am opening a pull request to enable Metal support. Currently, running on Mac platforms will default to CPU since CUDA is not available. However, the [Metal backend ](https://developer.apple.com/metal/pytorch/) for Apple devices has decent support in PyTorch and can significantly speed up the inference time of the network. 

In an example case I ran, my machine (MacBook Pro M1) took 1m7s to mask a CT image with the default model on CPU, but took only 5s to mask the same CT when the Metal backend was enabled. 

I tested all four provided models, and it seems that all four run on the Metal backend without issues. I also re-ran the tests under `tests/` and found that they still pass after this change (however some tests do force CPU).

Thanks for considering,
-Andrew